### PR TITLE
Simplify handling of kwargs; fix MethodError in tests

### DIFF
--- a/src/vec_tbl.jl
+++ b/src/vec_tbl.jl
@@ -299,19 +299,11 @@ function get_vec_tbl(OBJECT_NAME::ObjectName, START_TIME::DateTime,
 end
 
 function vec_tbl_csv(OBJECT_NAME::ObjectName, START_TIME::StartStopTime,
-        STOP_TIME::StartStopTime, STEP_SIZE::StepSize; timeout::Int=15,
-        EMAIL_ADDR::String="joe@your.domain.name", CENTER::String="@ssb",
-        REF_PLANE::String="FRAME", COORD_TYPE::String="G",
-        SITE_COORD::String="0,0,0", REF_SYSTEM::String="J2000",
-        VEC_CORR::Int=1, VEC_DELTA_T::Bool=false, OUT_UNITS::Int=1,
-        VEC_TABLE::VecTable=3)
+        STOP_TIME::StartStopTime, STEP_SIZE::StepSize; kwargs...)
 
     output_str, ftp_name = get_vec_tbl(OBJECT_NAME, DateTime(START_TIME),
-        DateTime(STOP_TIME), STEP_SIZE; timeout=timeout,
-        EMAIL_ADDR=EMAIL_ADDR, CENTER=CENTER, REF_PLANE=REF_PLANE,
-        COORD_TYPE=COORD_TYPE, SITE_COORD=SITE_COORD, REF_SYSTEM=REF_SYSTEM,
-        VEC_CORR=VEC_CORR, VEC_DELTA_T=VEC_DELTA_T, OUT_UNITS=OUT_UNITS,
-        CSV_FORMAT=true, VEC_LABELS=false, VEC_TABLE=VEC_TABLE)
+        DateTime(STOP_TIME), STEP_SIZE; CSV_FORMAT=true, VEC_LABELS=false,
+        kwargs...)
 
     # get $$SOE, $$EOE offsets
     mSOE = match(r"\$\$SOE", output_str)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,27 +17,6 @@ using HORIZONS, Expect
     @test idx == 2
 end
 
-@testset "Test for erroneous arguments" begin
-    @test_throws ArgumentError vec_tbl_csv("erroneous-input", Date(2000), Date(2010), Year(1))
-    @test_throws ArgumentError vec_tbl_csv(99942, Date(2000), Date(2010), Year(1); CENTER="nomatch")
-    @test_throws ArgumentError vec_tbl_csv(499, Date(2009), Date(2010), Year(1); VEC_TABLE = 1, CENTER="mars")
-    dt0 = Date(2000); dtmax = Date(2015); δt = Year(1)
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="w")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="%")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="c", SITE_COORD="a,b,c")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="c", SITE_COORD="")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; REF_PLANE="T", VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="c", SITE_COORD="10,1,1")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", "1400-1-1", dtmax, δt)
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", "bad-start-time", dtmax, δt)
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, "3500-2-1", δt)
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, "bad-stop-time", δt)
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, "1 w")
-    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, "bad-step_size")
-    @test_throws MethodError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_LABELS=0)
-    @test_throws TypeError vec_tbl("1950 DA", dt0, dtmax, δt; VEC_LABELS=0)
-end
-
 @testset "Vector table generation: vec_tbl" begin
     dt0 = DateTime(2029,4,13)
     dtmax = Date(2029,4,14)
@@ -157,4 +136,25 @@ end
     smb_spk("b", "DES= 2099942;", "2021-1-1", "2029-4-13T21:46:07.999", "joe@your.domain.name", "2099942_.bsp")
     smb_spk("b", "DES= 2099942;", "2021-1-1", "2029-4-13T21:46:07.999", "joe@your.domain.name", "2099942_.bsp", ftp_verbose=true)
     @test isfile("2099942_.bsp")
+end
+
+@testset "Test for erroneous arguments" begin
+    @test_throws ArgumentError vec_tbl_csv("erroneous-input", Date(2000), Date(2010), Year(1))
+    @test_throws ArgumentError vec_tbl_csv(99942, Date(2000), Date(2010), Year(1); CENTER="nomatch")
+    @test_throws ArgumentError vec_tbl_csv(499, Date(2009), Date(2010), Year(1); VEC_TABLE = 1, CENTER="mars")
+    dt0 = Date(2000); dtmax = Date(2015); δt = Year(1)
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="w")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="%")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="c", SITE_COORD="a,b,c")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="c", SITE_COORD="")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, δt; REF_PLANE="T", VEC_TABLE = "2xa", CENTER="coord", COORD_TYPE="c", SITE_COORD="10,1,1")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", "1400-1-1", dtmax, δt)
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", "bad-start-time", dtmax, δt)
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, "3500-2-1", δt)
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, "bad-stop-time", δt)
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, "1 w")
+    @test_throws ArgumentError vec_tbl_csv("1950 DA", dt0, dtmax, "bad-step_size")
+    @test_throws TypeError vec_tbl_csv("1950 DA", dt0, dtmax, δt; VEC_LABELS=0)
+    @test_throws TypeError vec_tbl("1950 DA", dt0, dtmax, δt; VEC_LABELS=0)
 end


### PR DESCRIPTION
This PR simplifies handling of keyword arguments in `vec_tbl` and associated functions, as well as fixing a test: a `MethodError` should actually be a `TypeError`. Also, for convenience while performing tests, the `"Test for erroneous arguments"` test set was moved towards the end of `test/runtests.jl`.