### PR TITLE
Update HTTP compat entry to v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
 [compat]
-HTTP = "1.10"
+HTTP = "2"
 JSON = "1"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "HORIZONS"
 uuid = "5a3ac768-beb4-554a-9c98-3342fe3377f5"
 repo = "https://github.com/PerezHz/HORIZONS.jl.git"
 authors = ["Jorge A. Pérez Hernández", "Luis Eduardo Ramírez Montoya"]
-version = "0.5.0"
+version = "0.6.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/HORIZONS.jl
+++ b/src/HORIZONS.jl
@@ -5,7 +5,7 @@
 module HORIZONS
 
 using HTTP, JSON, Base64, Dates
-using HTTP: Messages.Response
+using HTTP: Response
 
 export horizons, smb_spk, smb_spk_ele, vec_tbl, obs_tbl, sbdb, sbradar, scout, ooe_tbl
 


### PR DESCRIPTION
This PR updates the HTTP compat entry to v2, for which the minimum supported Julia version is 1.10 (LTS). @PerezHz do you agree to set the minimum supported Julia version to 1.10?